### PR TITLE
completing a task increments total and current user tokens with the task's token value (in firebase, not immediately in navbar yet)

### DIFF
--- a/src/components/TaskCard.js
+++ b/src/components/TaskCard.js
@@ -1,12 +1,25 @@
-import React from 'react';
+import { useEffect, useState } from 'react';
 import { Card, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCoins , faCircleInfo, faPenToSquare, faTrashCan, faCheckCircle } from '@fortawesome/free-solid-svg-icons';
+import { faCoins, faCircleInfo, faPenToSquare, faTrashCan, faCheckCircle } from '@fortawesome/free-solid-svg-icons';
 import Link from 'next/link';
 import { deleteTask } from '../api/taskData';
+import { useAuth } from '../utils/context/authContext';
+import { getUser, updateUser } from '../api/userData';
 
 export default function TaskCard({ taskObj, onUpdate }) {
+  // TODO: add onComplete as a prop
+
+  const { user } = useAuth();
+  const [userObj, setUserObj] = useState({});
+
+  useEffect(() => {
+    getUser(user.uid).then((data) => {
+      setUserObj(data);
+    });
+  }, []);
+
   // FOR DELETE, WE NEED TO REMOVE THE TASK AND HAVE THE VIEW RERENDER,
   // SO WE PASS THE FUNCTION FROM THE PARENT THAT GETS THE TASKS
   const deleteThisTask = () => {
@@ -14,6 +27,38 @@ export default function TaskCard({ taskObj, onUpdate }) {
       deleteTask(taskObj.firebaseKey).then(() => onUpdate());
     }
   };
+
+  const incrementUserTokens = () => {
+    // get the task's token value via taskObj.token_value
+    const taskTokenValue = taskObj.token_value;
+    console.log('taskTokenValue:', taskTokenValue);
+
+    // get the user object from firebase, this is done in the useEffect above
+
+    // define user's current token count
+    const userCurrentTokens = userObj[0]?.current_tokens;
+    console.log('userCurrentTokens:', userCurrentTokens);
+
+    // define user's lifetime token count
+    const userLifetimeTokens = userObj[0]?.lifetime_tokens;
+    console.log('userLifetimeTokens:', userLifetimeTokens);
+
+    // add taskObj.token_value to the user's token counts (current and lifetime)
+    const updatedUserCurrentTokens = userCurrentTokens + taskTokenValue;
+    console.log('updatedUserCurrentTokens:', updatedUserCurrentTokens);
+    const updatedUserLifetimeTokens = userLifetimeTokens + taskTokenValue;
+    console.log('updatedUserLifetimeTokens:', updatedUserLifetimeTokens);
+
+    const payload = { ...userObj[0], current_tokens: updatedUserCurrentTokens, lifetime_tokens: updatedUserLifetimeTokens };
+    // update the user object in firebase
+    updateUser(payload).then(() => {
+      // update the user object in state
+      setUserObj(payload);
+    });
+
+    // TODO: .then(() => onComplete()); (make sure to pass onComplete as a prop to TaskCard where it is used, and make it fetch the user object again)
+  };
+
   return (
     <Card style={{ width: '18rem' }}>
       {/* task name */}
@@ -54,7 +99,7 @@ export default function TaskCard({ taskObj, onUpdate }) {
 
         {/* complete button */}
         <OverlayTrigger placement="bottom" overlay={<Tooltip id={`tooltip-${taskObj.firebaseKey}`}>Complete</Tooltip>}>
-          <FontAwesomeIcon className="m-2 fa-2x" icon={faCheckCircle} style={{ color: 'green', fontSize: '2.2rem' }} />
+          <FontAwesomeIcon className="m-2 fa-2x" icon={faCheckCircle} style={{ color: 'green', fontSize: '2.2rem' }} onClick={incrementUserTokens} />
         </OverlayTrigger>
       </div>
     </Card>

--- a/src/utils/hooks/useUser.js
+++ b/src/utils/hooks/useUser.js
@@ -25,8 +25,10 @@ const useUser = () => {
 
               createUser(payload).then(({ name }) => {
                 const patchPayload = { ...payload, firebaseKey: name };
-                updateUser(patchPayload);
-                setUserData(patchPayload);
+                return updateUser(patchPayload).then(() => {
+                  // wait for updateUser to complete
+                  setUserData(patchPayload); // set userData after updateUser completes
+                });
               });
             } else {
               // If user exists, set userData from existing user


### PR DESCRIPTION
This pull request includes several changes to the `TaskCard` component and a small improvement to the `useUser` hook. The most important changes include adding user token increment functionality when a task is completed and ensuring user data is set correctly after updating.

Enhancements to `TaskCard` component:

* [`src/components/TaskCard.js`](diffhunk://#diff-5e8f07d340a677e2ec15bdf546ac3d30387446f7b8fdbb34a9cf5c154fb02e88L1-R61): Imported `useEffect`, `useState`, `useAuth`, `getUser`, and `updateUser` to manage user state and update tokens upon task completion.
* [`src/components/TaskCard.js`](diffhunk://#diff-5e8f07d340a677e2ec15bdf546ac3d30387446f7b8fdbb34a9cf5c154fb02e88L1-R61): Added `incrementUserTokens` function to handle the logic of updating user's current and lifetime tokens when a task is marked as complete.
* [`src/components/TaskCard.js`](diffhunk://#diff-5e8f07d340a677e2ec15bdf546ac3d30387446f7b8fdbb34a9cf5c154fb02e88L57-R102): Modified the complete button to call `incrementUserTokens` on click, triggering the token update process.

Improvements to `useUser` hook:

* [`src/utils/hooks/useUser.js`](diffhunk://#diff-1ef7400c3e6653c7d1a7ca6cb801c34d18d6d08626474c51c5b1e192f8c5aa33L28-R31): Ensured `setUserData` is called only after `updateUser` completes to maintain data consistency.