### PR TITLE
fixed new user ui token issue

### DIFF
--- a/src/utils/hooks/useUser.js
+++ b/src/utils/hooks/useUser.js
@@ -29,11 +29,17 @@ const useUser = () => {
                 return updateUser(patchPayload).then(() => {
                   // wait for updateUser to complete
                   setUserData(patchPayload); // set userData after updateUser completes
+
+                  // ensure loading is false only after setting userData
+                  setLoading(false); // Stop loading when done
                 });
               });
             } else {
               // *****  IF USER ALREADY EXISTS, SET USER DATA FROM EXISTING USER *****
               setUserData(existingUser[0]);
+
+              // Only stop loading when userData is set
+              setLoading(false); // Stop loading when done
             }
             // *****  AFTER EITHER CREATING OR UPDATING USER DATA, STOP LOADING. (SET LOADING TO FALSE WHEN USER DATA IS AVAILABLE) *****
             // the loading boolean is used in the ViewDirector to show a loading spinner while user data is being fetched


### PR DESCRIPTION
## Description

issue:
login in as a brand new user, the nav bar didn't show # of tokens in nav bar without refreshing first. this happened because getting user info in the navbar mount was running before that new user obj was fully created.

solution:
Edited useUser so 'loading' stayed true until userData was fully set, so navbar wouldn't render until after (this happens in viewDirector). now number of tokens displays in navbar without refreshing!


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
